### PR TITLE
Adds the 'noack' to `xreadgroup`

### DIFF
--- a/redis/client.py
+++ b/redis/client.py
@@ -1955,7 +1955,7 @@ class StrictRedis(object):
         return self.execute_command('XTRIM', name, *pieces)
 
     def xreadgroup(self, groupname, consumername, streams, count=None,
-                   block=None):
+                   block=None, noack=False):
         """
         Read from a stream via a consumer group.
         groupname: name of the consumer group.
@@ -1965,6 +1965,8 @@ class StrictRedis(object):
         count: if set, only return this many items, beginning with the
                earliest available.
         block: number of milliseconds to wait, if nothing already present.
+        noack: if True, messages are not added to the consumer's pending
+               entries list (equivalent to immediate acknowledgement).
         """
         pieces = [Token.get_token('GROUP'), groupname, consumername]
         if count is not None:
@@ -1978,6 +1980,8 @@ class StrictRedis(object):
                                  "integer")
             pieces.append(Token.get_token("BLOCK"))
             pieces.append(str(block))
+        if noack:
+            pieces.append(Token.get_token("NOACK"))
         if not isinstance(streams, dict) or len(streams) == 0:
             raise RedisError('XREADGROUP streams must be a non empty dict')
         pieces.append(Token.get_token('STREAMS'))


### PR DESCRIPTION
Signed-off-by: Itamar Haber <itamar@redislabs.com>